### PR TITLE
Enable **all** intents to fix bot join logs

### DIFF
--- a/CatLampPY.py
+++ b/CatLampPY.py
@@ -67,7 +67,7 @@ while True:
     break
 
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(name)s | %(message)s")
-intents = discord.Intents.default()
+intents = discord.Intents.all()
 client = commands.AutoShardedBot(
     command_prefix=commands.when_mentioned_or('+'), case_insensitive=True, intents=intents,
     help_command=EmbedHelpCommand(verify_checks=False, show_hidden=False), chunk_guilds_at_startup=False


### PR DESCRIPTION
This will require the intents to be enabled for the Catlamp bot account(s).